### PR TITLE
extract urls field

### DIFF
--- a/core/fastsync.go
+++ b/core/fastsync.go
@@ -29,6 +29,7 @@ type FSArticle struct{
 	Year int `json:"year"`
 	Topics []string `json:"topics"`
 	Subjects []string `json:"subjects"`
+	URLs []string `json:"urls"`
 	FullText string `json:"fullText"`
 }
 

--- a/core/fastsync_test.go
+++ b/core/fastsync_test.go
@@ -60,6 +60,10 @@ var expFSArticle = &FSArticle{
 	Topics: []string{
 		"L500",
 	},
+	URLs :[]string{
+		"http://example.com/1",
+		"http://www.example.com/2",
+	},
 	FullText: "RESEARCH REPORT\n'Standing on my own two feet':\nDisadvantaged Teenagers, Intimate Partner Violence  \nand Coercive Control\n",
 }
 
@@ -106,6 +110,7 @@ var testFSData = []byte(`{
   "subject": [
     "L500"
   ],
+ "urls": ["http://example.com/1", "http://www.example.com/2"],
   "repositories": {
     "id": "18",
     "name": "CLoK",


### PR DESCRIPTION
CORE have added an array of urls that were found in the original metadata for the article. This change allows you to extract those making them available for any further processing