### PR TITLE
update journals to slice

### DIFF
--- a/core/fastsync.go
+++ b/core/fastsync.go
@@ -23,7 +23,7 @@ type FSArticle struct{
 	PDFHashValue string `json:"pdfHashValue"`
 	Publisher string `json:"publisher"`
 	RawRecordXML string `json:"rawRecordXML"`
-	Journal FSJournal `json:"journals"`
+	Journals []FSJournal `json:"journals"`
 	Language FSLanguage `json:"language"`
 	Relations []string `json:"relations"`
 	Year int `json:"year"`

--- a/core/fastsync_test.go
+++ b/core/fastsync_test.go
@@ -66,6 +66,15 @@ var expFSArticle = &FSArticle{
 	PDFHashValue: "97a86466f1afdd62cd885ef03fc75c483bef767d",
 	Publisher: "NSPCC",
 	RawRecordXML: "<record><header><identifier>\n    \n    \n      oai:clok.uclan.ac.uk:14639</identifier><datestamp>\n      2017-10-11T13:40:45Z</datestamp><setSpec>\n      7374617475733D707562</setSpec><setSpec>\n      7375626A656374733D4C303030:4C353030</setSpec><setSpec>\n      74797065733D6D6F6E6F6772617068</setSpec></header><metadata><rioxx xmlns=\"http://www.rioxx.net/schema/v2.0/rioxx/\" xmlns:ali=\"http://ali.niso.org/2014/ali/1.0\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" xmlns:rioxxterms=\"http://docs.rioxx.net/schema/v2.0/rioxxterms/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.rioxx.net/schema/v2.0/rioxx/ http://www.rioxx.net/schema/v2.0/rioxx/rioxx.xsd\" ><ali:free_to_read>\n    \n      </ali:free_to_read><ali:license_ref start_date=\"2010\" >http://creativecommons.org/licenses/by-nc-nd/3.0</ali:license_ref><dc:format>application/pdf</dc:format><dc:identifier>http://clok.uclan.ac.uk/14639/1/standing-own-two-feet-report.pdf</dc:identifier><dc:language>en</dc:language><dc:publisher>NSPCC</dc:publisher><dc:subject>L500</dc:subject><dc:title>Research Report: 'Standing on my own two feet': Disadvantaged Teenagers, Intimate Partner Violence and Coercive Control</dc:title><rioxxterms:author>Wood, Marsha</rioxxterms:author><rioxxterms:author>Barter, Christine</rioxxterms:author><rioxxterms:author>Berridge, David</rioxxterms:author><rioxxterms:publication_date>2010</rioxxterms:publication_date><rioxxterms:type>Monograph</rioxxterms:type><rioxxterms:version>VoR</rioxxterms:version></rioxx></metadata></record>",
+	Journals: []FSJournal{
+		{
+			Title: "",
+			Identifiers: []string{
+				"issn:0143-7739",
+				"0143-7739",
+			},
+		},
+	},
 	Language: FSLanguage {
 		Code:  "en",
 		Name: "English",
@@ -131,7 +140,15 @@ var testFSData = []byte(`{
   "pdfHashValue": "97a86466f1afdd62cd885ef03fc75c483bef767d",
   "publisher": "NSPCC",
   "rawRecordXml": "<record><header><identifier>\n    \n    \n      oai:clok.uclan.ac.uk:14639</identifier><datestamp>\n      2017-10-11T13:40:45Z</datestamp><setSpec>\n      7374617475733D707562</setSpec><setSpec>\n      7375626A656374733D4C303030:4C353030</setSpec><setSpec>\n      74797065733D6D6F6E6F6772617068</setSpec></header><metadata><rioxx xmlns=\"http://www.rioxx.net/schema/v2.0/rioxx/\" xmlns:ali=\"http://ali.niso.org/2014/ali/1.0\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" xmlns:rioxxterms=\"http://docs.rioxx.net/schema/v2.0/rioxxterms/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.rioxx.net/schema/v2.0/rioxx/ http://www.rioxx.net/schema/v2.0/rioxx/rioxx.xsd\" ><ali:free_to_read>\n    \n      </ali:free_to_read><ali:license_ref start_date=\"2010\" >http://creativecommons.org/licenses/by-nc-nd/3.0</ali:license_ref><dc:format>application/pdf</dc:format><dc:identifier>http://clok.uclan.ac.uk/14639/1/standing-own-two-feet-report.pdf</dc:identifier><dc:language>en</dc:language><dc:publisher>NSPCC</dc:publisher><dc:subject>L500</dc:subject><dc:title>Research Report: 'Standing on my own two feet': Disadvantaged Teenagers, Intimate Partner Violence and Coercive Control</dc:title><rioxxterms:author>Wood, Marsha</rioxxterms:author><rioxxterms:author>Barter, Christine</rioxxterms:author><rioxxterms:author>Berridge, David</rioxxterms:author><rioxxterms:publication_date>2010</rioxxterms:publication_date><rioxxterms:type>Monograph</rioxxterms:type><rioxxterms:version>VoR</rioxxterms:version></rioxx></metadata></record>",
-  "journals": null,
+  "journals": [
+    {
+      "title": null,
+      "identifiers": [
+        "issn:0143-7739",
+        "0143-7739"
+      ]
+    }
+  ],
   "language": {
     "code": "en",
     "id": 9,


### PR DESCRIPTION
Following experience using the API in the real world it  is clear that the Journals field is a slice of objects, not just one object.

This updates the tests and the code to support that.